### PR TITLE
added model_downloader using pooch

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -19,6 +19,7 @@ dependencies:
   - h5py
   - pytorch=2.1.2
   - torchvision
+  - pooch
   - pip
   - pip:
     - numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     magicgui
     qtpy
     h5py
+    pooch
     ; pytorch
     ; torchvision
     timm

--- a/src/featureforest/SAM/setup_model.py
+++ b/src/featureforest/SAM/setup_model.py
@@ -12,10 +12,14 @@ def setup_mobile_sam_model():
     # sam model (light hq sam)
     model = MobileSAM.setup_model().to(device)
     # download model's weights
+    model_url = "https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt"
     model_file = download_model(
-        model_url="https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt",
+        model_url=model_url,
         model_name="mobile_sam.pt"
     )
+    if model_file is None:
+        raise ValueError(f"Could not download the model from {model_url}.")
+
     # load weights
     weights = torch.load(model_file, map_location=device)
     model.load_state_dict(weights, strict=True)

--- a/src/featureforest/SAM/setup_model.py
+++ b/src/featureforest/SAM/setup_model.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import torch
 
+from ..utils.downloader import download_model
 from .models import MobileSAM
 
 
@@ -10,13 +11,13 @@ def setup_mobile_sam_model():
     print(f"running on {device}")
     # sam model (light hq sam)
     model = MobileSAM.setup_model().to(device)
-    # load weights
-    weights = torch.load(
-        Path(__file__).parent.joinpath(
-            "./models/weights/mobile_sam.pt"
-        ),
-        map_location=device
+    # download model's weights
+    model_file = download_model(
+        model_url="https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt",
+        model_name="mobile_sam.pt"
     )
+    # load weights
+    weights = torch.load(model_file, map_location=device)
     model.load_state_dict(weights, strict=True)
     model.eval()
 

--- a/src/featureforest/utils/downloader.py
+++ b/src/featureforest/utils/downloader.py
@@ -43,11 +43,3 @@ def download_model(
     except Exception as err:
         print(f"\nError while downloading the model:\n{err}")
         return None
-
-
-if __name__ == "__main__":
-    model_file = download_model(
-        model_url="https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt",
-        model_name="mobile_sam.pt"
-    )
-    print(model_file)

--- a/src/featureforest/utils/downloader.py
+++ b/src/featureforest/utils/downloader.py
@@ -2,13 +2,7 @@ from pathlib import Path
 import pooch
 
 
-MODELS_CACHE_DIR = Path.home().joinpath(".featureforest").joinpath("models")
-MODELS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def is_model_exists(model_name: str) -> bool:
-    model_file = MODELS_CACHE_DIR.joinpath(model_name)
-    return model_file.exists()
+MODELS_CACHE_DIR = Path.home().joinpath(".featureforest", "models")
 
 
 def download_model(
@@ -27,9 +21,6 @@ def download_model(
     Returns:
         str: full path of the downloaded file.
     """
-    if is_model_exists(model_name):
-        return str(MODELS_CACHE_DIR.joinpath(model_name).absolute())
-
     try:
         downloaded_file = pooch.retrieve(
             url=model_url,

--- a/src/featureforest/utils/downloader.py
+++ b/src/featureforest/utils/downloader.py
@@ -29,6 +29,14 @@ def download_model(
             known_hash=None,
             processor=pooch.Unzip() if is_archived else None
         )
+        # for zip files, get the file ending with "pt" or "pth" as model weights file.
+        if is_archived:
+            pytorch_files = [
+                f for f in downloaded_file
+                if Path(f).suffix in ["pt", "pth"]
+            ]
+            downloaded_file = pytorch_files[0] if len(pytorch_files) > 0 else None
+
         return downloaded_file
 
     except Exception as err:

--- a/src/featureforest/utils/downloader.py
+++ b/src/featureforest/utils/downloader.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import pooch
+
+
+MODELS_CACHE_DIR = Path.home().joinpath(".featureforest").joinpath("models")
+MODELS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def is_model_exists(model_name: str) -> bool:
+    model_file = MODELS_CACHE_DIR.joinpath(model_name)
+    return model_file.exists()
+
+
+def download_model(
+    model_url: str, model_name: str,
+    cache_dir: Path = MODELS_CACHE_DIR, is_archived: bool = False
+) -> str:
+    """Download a model weights from a given url.
+
+    Args:
+        model_url (str): the model weights' url.
+        model_name (str): model's name that will be saved in cache.
+        cache_dir (Path, optional): download directory. Defaults to CACHE_DIR.
+        is_archived (bool, optional):   set to True to unzip the downloaded file.
+                                        Defaults to False.
+
+    Returns:
+        str: full path of the downloaded file.
+    """
+    if is_model_exists(model_name):
+        return str(MODELS_CACHE_DIR.joinpath(model_name).absolute())
+
+    try:
+        downloaded_file = pooch.retrieve(
+            url=model_url,
+            fname=model_name,
+            path=cache_dir,
+            known_hash=None,
+            processor=pooch.Unzip() if is_archived else None
+        )
+        return downloaded_file
+
+    except Exception as err:
+        print(f"\nError while downloading the model:\n{err}")
+        return None
+
+
+if __name__ == "__main__":
+    model_file = download_model(
+        model_url="https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt",
+        model_name="mobile_sam.pt"
+    )
+    print(model_file)


### PR DESCRIPTION
The `download_model` function resides in `utils/downloader.py`. First, it will check the model availability in the *featureforest* cache directory, and if the requested model is not there, it will be downloaded.
