### PR TITLE
Added large SAM model adapter (vit_h)

### DIFF
--- a/src/featureforest/models/DinoV2/__init__.py
+++ b/src/featureforest/models/DinoV2/__init__.py
@@ -1,2 +1,8 @@
 from .model import get_model
 from .adapter import DinoV2Adapter
+
+
+__all__ = [
+    "get_model",
+    "DinoV2Adapter",
+]

--- a/src/featureforest/models/SAM/__init__.py
+++ b/src/featureforest/models/SAM/__init__.py
@@ -1,8 +1,8 @@
 from .model import get_model
-from .adapter import MobileSAMAdapter
+from .adapter import SAMAdapter
 
 
 __all__ = [
     "get_model",
-    "MobileSAMAdapter",
+    "SAMAdapter"
 ]

--- a/src/featureforest/models/SAM/adapter.py
+++ b/src/featureforest/models/SAM/adapter.py
@@ -1,0 +1,80 @@
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torchvision.transforms import v2 as tv_transforms2
+
+from featureforest.models.base import BaseModelAdapter
+from featureforest.utils.data import (
+    get_patch_size,
+    get_nonoverlapped_patches,
+)
+
+
+class SAMAdapter(BaseModelAdapter):
+    """SAM model adapter (vit_h)
+    """
+    def __init__(
+        self,
+        image_encoder: nn.Module,
+        img_height: float,
+        img_width: float,
+    ) -> None:
+        super().__init__(image_encoder, img_height, img_width)
+        self.name = "SAM"
+        # we need sam image encoder part
+        self.encoder = image_encoder
+        self.encoder_num_channels = 256
+        self.embed_layer_num_channels = 1280
+        self._set_patch_size()
+        # input transform for sam
+        self.sam_input_dim = 1024
+        self.input_transforms = tv_transforms2.Compose([
+            tv_transforms2.Resize(
+                (self.sam_input_dim, self.sam_input_dim),
+                interpolation=tv_transforms2.InterpolationMode.BICUBIC,
+                antialias=True
+            ),
+        ])
+        # to transform feature patches back to the original patch size
+        self.embedding_transform = tv_transforms2.Compose([
+            tv_transforms2.Resize(
+                (self.patch_size, self.patch_size),
+                interpolation=tv_transforms2.InterpolationMode.BICUBIC,
+                antialias=True
+            ),
+        ])
+
+    def _set_patch_size(self) -> None:
+        self.patch_size = get_patch_size(self.img_height, self.img_width)
+        self.overlap = 3 * self.patch_size // 4
+
+    def get_features_patches(
+        self, in_patches: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        # get the mobile-sam encoder and embedding layer outputs
+        with torch.no_grad():
+            # output: b,256,64,64
+            output = self.encoder(
+                self.input_transforms(in_patches)
+            )
+            # embed_output: b,64,64,1280 -> b,1280,64,64
+            embed_output = self.encoder.patch_embed(
+                self.input_transforms(in_patches)
+            ).permute(0, 3, 1, 2)
+
+        # get non-overlapped feature patches
+        out_feature_patches = get_nonoverlapped_patches(
+            self.embedding_transform(output.cpu()),
+            self.patch_size, self.overlap
+        )
+        embed_feature_patches = get_nonoverlapped_patches(
+            self.embedding_transform(embed_output.cpu()),
+            self.patch_size, self.overlap
+        )
+
+        return out_feature_patches, embed_feature_patches
+
+    def get_total_output_channels(self) -> int:
+        return self.encoder_num_channels + self.embed_layer_num_channels

--- a/src/featureforest/models/SAM/model.py
+++ b/src/featureforest/models/SAM/model.py
@@ -19,7 +19,7 @@ def get_model(
         "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
     model_file = download_model(
         model_url=model_url,
-        model_name="sam_vit_h.pt"
+        model_name="sam_vit_h_4b8939.pt"
     )
     if model_file is None:
         raise ValueError(f"Could not download the model from {model_url}.")

--- a/src/featureforest/models/SAM/model.py
+++ b/src/featureforest/models/SAM/model.py
@@ -19,7 +19,7 @@ def get_model(
         "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
     model_file = download_model(
         model_url=model_url,
-        model_name="sam_vit_h_4b8939.pt"
+        model_name="sam_vit_h_4b8939.pth"
     )
     if model_file is None:
         raise ValueError(f"Could not download the model from {model_url}.")

--- a/src/featureforest/models/SAM/model.py
+++ b/src/featureforest/models/SAM/model.py
@@ -1,0 +1,38 @@
+from typing import Tuple
+
+import torch
+
+from segment_anything.modeling import Sam
+from segment_anything import sam_model_registry
+
+from featureforest.utils.downloader import download_model
+from .adapter import SAMAdapter
+
+
+def get_model(
+    img_height: float, img_width: float, *args, **kwargs
+) -> Tuple[SAMAdapter, torch.device]:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"running on {device}")
+    # download model's weights
+    model_url = \
+        "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
+    model_file = download_model(
+        model_url=model_url,
+        model_name="sam_vit_h.pt"
+    )
+    if model_file is None:
+        raise ValueError(f"Could not download the model from {model_url}.")
+
+    # init the model
+    model: Sam = sam_model_registry["vit_h"](checkpoint=model_file)
+    # to save some GPU memory, only put the encoder part on GPU
+    sam_image_encoder = model.image_encoder.to(device)
+    sam_image_encoder.eval()
+
+    # create the model adapter
+    sam_model_adapter = SAMAdapter(
+        sam_image_encoder, img_height, img_width
+    )
+
+    return sam_model_adapter, device

--- a/src/featureforest/models/__init__.py
+++ b/src/featureforest/models/__init__.py
@@ -4,11 +4,13 @@ import torch
 
 from .base import BaseModelAdapter
 from .MobileSAM import get_model as get_mobile_sam_model
+from .SAM import get_model as get_sam_model
 from .DinoV2 import get_model as get_dino_v2_model
 
 
 _MODELS_DICT = {
     "MobileSAM": get_mobile_sam_model,
+    "SAM": get_sam_model,
     "DinoV2": get_dino_v2_model,
 }
 

--- a/src/featureforest/utils/extract.py
+++ b/src/featureforest/utils/extract.py
@@ -9,6 +9,7 @@ from .data import (
     is_image_rgb,
 )
 from featureforest.models.base import BaseModelAdapter
+from featureforest.models.SAM import SAMAdapter
 
 
 def get_slice_features(
@@ -42,7 +43,13 @@ def get_slice_features(
     # get input patches
     data_patches = patchify(img_data, patch_size, overlap)
     num_patches = len(data_patches)
-    batch_size = 10
+
+    # set a low batch size
+    batch_size = 8
+    # for big SAM we need even lower batch size :(
+    if isinstance(model_adapter, SAMAdapter):
+        batch_size = 2
+
     num_batches = int(np.ceil(num_patches / batch_size))
     # prepare storage for the slice embeddings
     total_channels = model_adapter.get_total_output_channels()


### PR DESCRIPTION
For the big SAM model: 
- Extracted features coming out of the encoder have the shape of `b,256,64,64`.  
- The `patch_embed` layer inside the encoder will be called again with given input patches to produce the output of shape `b,1280,64,64`.
- So, the final feature dim for each pixel is `256 + 1280 = 1536`.  
