### PR TITLE
updated post-processing using LightHQSAM

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -28,4 +28,5 @@ dependencies:
     - timm
     - pynrrd
     - git+https://github.com/facebookresearch/segment-anything.git
+    - segment-anything-hq
     - git+https://github.com/juglab/featureforest.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     ; torchvision
     timm
     segment-anything @ git+https://github.com/facebookresearch/segment-anything.git
+    segment-anything-hq
 
 [options.packages.find]
 where = src

--- a/src/featureforest/_segmentation_widget.py
+++ b/src/featureforest/_segmentation_widget.py
@@ -35,7 +35,7 @@ from .utils import (
 from .utils.postprocess import (
     postprocess_segmentation,
 )
-# from .utils.postprocess_with_sam import postprocess_segmentations_with_sam
+from .utils.postprocess_with_sam import postprocess_segmentations_with_sam
 
 
 class SegmentationWidget(QWidget):
@@ -634,14 +634,14 @@ class SegmentationWidget(QWidget):
             area_threshold = None
             if len(self.area_threshold_textbox.text()) > 0:
                 area_threshold = float(self.area_threshold_textbox.text()) / 100
-            # if self.sam_post_checkbox.checkState() == Qt.Checked:
-            #     segmentation_image = postprocess_segmentations_with_sam(
-            #         self.model_adapter, segmentation_image, area_threshold
-            #     )
-            # else:
-            segmentation_image = postprocess_segmentation(
-                segmentation_image, area_threshold
-            )
+            if self.sam_post_checkbox.checkState() == Qt.Checked:
+                segmentation_image = postprocess_segmentations_with_sam(
+                    segmentation_image, area_threshold
+                )
+            else:
+                segmentation_image = postprocess_segmentation(
+                    segmentation_image, area_threshold
+                )
 
         return segmentation_image
 


### PR DESCRIPTION
The postprocessing using the `SAM Predictor` is updated:
- Using **Light HQ SAM** from [_Segment Anything in High Quality_](https://github.com/SysCV/sam-hq).
- On the first use, the model's weight will be downloaded.
- A new dependency to the mentioned package is added.

The post-processing still happening using the `predict` button.