### PR TITLE
Bug fix: calculating the right amount of padding to add to image

### DIFF
--- a/src/featureforest/_segmentation_widget.py
+++ b/src/featureforest/_segmentation_widget.py
@@ -309,7 +309,7 @@ class SegmentationWidget(QWidget):
         validator = QDoubleValidator(0.0, 1.0, 2)
         validator.setNotation(QDoubleValidator.StandardNotation)
         self.sam_auto_threshold_textbox.setValidator(validator)
-        self.sam_auto_threshold_textbox.setText("0.45")
+        self.sam_auto_threshold_textbox.setText("0.35")
         self.sam_auto_threshold_textbox.setToolTip(
             "Keeps prediction mask regions with having IOU against SAM generated masks"
             " above the threshold (should be between [0, 1])."

--- a/src/featureforest/models/DinoV2/adapter.py
+++ b/src/featureforest/models/DinoV2/adapter.py
@@ -46,7 +46,7 @@ class DinoV2Adapter(BaseModelAdapter):
 
     def _set_patch_size(self) -> None:
         self.patch_size = self.dino_patch_size * 5
-        self.overlap = self.dino_patch_size * 3
+        self.overlap = self.dino_patch_size * 2
 
     def get_features_patches(
         self, in_patches: Tensor

--- a/src/featureforest/utils/data.py
+++ b/src/featureforest/utils/data.py
@@ -42,7 +42,7 @@ def get_patch_size(
 
 
 def get_stride_margin(patch_size: int, overlap: int) -> Tuple[int, int]:
-    """Calculate the sliding stride (step), and the margin needs to be added to image
+    """Calculate the patching stride (step), and the margin pad needed to be added to image
         to have complete patches covering all pixels.
 
     Args:
@@ -53,7 +53,7 @@ def get_stride_margin(patch_size: int, overlap: int) -> Tuple[int, int]:
         Tuple[int, int]: sliding stride and margin
     """
     stride = patch_size - overlap
-    margin = (patch_size - stride) // 2
+    margin = overlap // 2
     return stride, margin
 
 
@@ -99,9 +99,9 @@ def patchify(
     _, c, img_height, img_width = images.shape
     if patch_size is None:
         patch_size = get_patch_size(img_height, img_width)
-        overlap = 3 * patch_size // 4
+        overlap = patch_size // 2
     if overlap is None:
-        overlap = 3 * patch_size // 4
+        overlap = patch_size // 2
 
     stride, margin = get_stride_margin(patch_size, overlap)
     pad_right, pad_bottom = get_paddings(patch_size, margin, img_height, img_width)
@@ -136,10 +136,10 @@ def get_num_patches(
     pad_right, pad_bottom = get_paddings(patch_size, margin, img_height, img_width)
     num_patches_w = (img_width + pad_right) / stride
     assert int(num_patches_w) == num_patches_w, \
-        f"number of width patches {num_patches_w} is not integer!"
+        f"number of patches in width {num_patches_w} is not an integer!"
     num_patches_h = (img_height + pad_bottom) / stride
     assert int(num_patches_h) == num_patches_h, \
-        f"number of height patches {num_patches_h} is not integer!"
+        f"number of patches in height {num_patches_h} is not an integer!"
 
     return int(num_patches_h), int(num_patches_w)
 


### PR DESCRIPTION
There was a bug with the padding calculation and the number of patches per image.  
I'm using pytorch `unfold` function for creating patches, so the padding should be compatible with this function:  
pad amount should be enough to make the `(final size - patch_size) / stride` an integer number.
see [torch.nn.Unfold](https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html).