### PR TITLE
Plugin usage statistics

### DIFF
--- a/src/featureforest/_feature_extractor_widget.py
+++ b/src/featureforest/_feature_extractor_widget.py
@@ -215,7 +215,7 @@ class FeatureExtractorWidget(QWidget):
         self.time_label.setText(f"Extraction Time: {int(minutes)} minutes and {int(seconds)} seconds")
         # save the stats
         storage_path = Path(self.storage_textbox.text())
-        csv_path = storage_path.parent.joinpath(f"{storage_path.stem}.csv")
+        csv_path = storage_path.parent.joinpath(f"{storage_path.stem}_ext_stats.csv")
         with open(csv_path, mode="w") as f:
             writer = csv.DictWriter(f, fieldnames=["total", "avg_per_slice"])
             writer.writeheader()

--- a/src/featureforest/utils/usage_stats.py
+++ b/src/featureforest/utils/usage_stats.py
@@ -1,0 +1,68 @@
+import time
+
+
+class SegmentationUsageStats:
+    def __init__(self):
+        self.labeling_start = 0
+        self.last_label_on = 0
+        self.num_training = 0
+        self.last_training_time = 0
+        self.avg_training_time = 0
+        self.num_prediction = 0
+        self.prediction_time = 0
+        self.label_layer = None  # napari active labeling layer
+        self.file_path = ""
+        self._training_start = 0
+        self._prediction_start = 0
+
+    def set_label_layer(self, layer):
+        # same old shhh :)
+        if self.label_layer == layer:
+            return
+        # release the old layer event
+        if self.label_layer is not None:
+            self.label_layer.events.label_update.disconnect()
+        # set the new one
+        self.label_layer = layer
+        self.label_layer.events.labels_update.connect(self._on_label_updated)
+
+    def training_started(self):
+        self._training_start = time.perf_counter()
+
+    def count_training(self):
+        self.last_training_time = time.perf_counter() - self._training_start
+        self.num_training += 1
+        old_avg = self.avg_training_time
+        self.avg_training_time = (
+            old_avg * (self.num_training - 1) + self.last_training_time) / self.num_training
+
+    def prediction_started(self):
+        self._prediction_start = time.perf_counter()
+
+    def count_prediction(self):
+        self.num_prediction += 1
+        self.prediction_time = time.perf_counter() - self._prediction_start
+
+    def reset(self):
+        self.labeling_start = 0
+        self.last_label_on = 0
+        self.num_training = 0
+        self.last_training_time = 0
+        self.avg_training_time = 0
+        self.num_prediction = 0
+        self.prediction_time = 0
+        # self.label_layer = None
+        # self.file_path = ""
+        self._training_start = 0
+        self._prediction_start = 0
+
+    def _on_label_updated(self):
+        if self.labeling_start == 0:
+            self.labeling_start = time.perf_counter()
+        self.last_label_on = time.perf_counter()
+
+    def format_seconds(self, seconds):
+        pass
+
+    def to_dataframe(self):
+        pass

--- a/src/featureforest/utils/usage_stats.py
+++ b/src/featureforest/utils/usage_stats.py
@@ -1,5 +1,14 @@
 import time
 
+import pandas as pd
+
+
+
+def format_seconds(total_seconds):
+    minutes, seconds = divmod(total_seconds, 60)
+    nice = f"{int(minutes)} minutes and {int(seconds)} seconds"
+    return nice, int(minutes), int(seconds)
+
 
 class SegmentationUsageStats:
     def __init__(self):
@@ -16,7 +25,7 @@ class SegmentationUsageStats:
         self._prediction_start = 0
 
     def set_label_layer(self, layer):
-        # same old shhh :)
+        # if the same old shhh :)
         if self.label_layer == layer:
             return
         # release the old layer event
@@ -25,6 +34,9 @@ class SegmentationUsageStats:
         # set the new one
         self.label_layer = layer
         self.label_layer.events.labels_update.connect(self._on_label_updated)
+
+    def set_file_path(self, path):
+        self.file_path = path
 
     def training_started(self):
         self._training_start = time.perf_counter()
@@ -35,6 +47,8 @@ class SegmentationUsageStats:
         old_avg = self.avg_training_time
         self.avg_training_time = (
             old_avg * (self.num_training - 1) + self.last_training_time) / self.num_training
+        # save the stats
+        self.save_as_csv()
 
     def prediction_started(self):
         self._prediction_start = time.perf_counter()
@@ -42,6 +56,8 @@ class SegmentationUsageStats:
     def count_prediction(self):
         self.num_prediction += 1
         self.prediction_time = time.perf_counter() - self._prediction_start
+        # save the stats
+        self.save_as_csv()
 
     def reset(self):
         self.labeling_start = 0
@@ -60,9 +76,27 @@ class SegmentationUsageStats:
         if self.labeling_start == 0:
             self.labeling_start = time.perf_counter()
         self.last_label_on = time.perf_counter()
-
-    def format_seconds(self, seconds):
-        pass
+        # save the stats
+        self.save_as_csv()
 
     def to_dataframe(self):
-        pass
+        data = {}
+        data["labeling"] = format_seconds(self.last_label_on - self.labeling_start)[0]
+        data["last_training"] = round(self.last_training_time / 60, 2)
+        data["average_training"] = round(self.avg_training_time / 60, 2)
+        data["num_trainings"] = self.num_training
+        data["prediction_time"] = round(self.prediction_time / 60, 2)
+        data["num_predictions"] = self.num_prediction
+
+        return pd.DataFrame(data, index=[0])
+
+    def save_as_csv(self, file_path=None):
+        where_to_save = self.file_path
+        if file_path is not None:
+            where_to_save = file_path
+        if where_to_save is not None:
+            df = self.to_dataframe()
+            df.to_csv(where_to_save, index=False)
+            print(f"Plugin usage stats is saved at {where_to_save}")
+        else:
+            print("Don't know where to save it!")

--- a/src/featureforest/widgets/__init__.py
+++ b/src/featureforest/widgets/__init__.py
@@ -1,4 +1,5 @@
 from .scroll_wrapper import ScrollWidgetWrapper
+from .usage_stats import UsageStats
 from .utils import (
     get_layer,
 )

--- a/src/featureforest/widgets/usage_stats.py
+++ b/src/featureforest/widgets/usage_stats.py
@@ -1,9 +1,8 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
-    QWidget, QHBoxLayout, QVBoxLayout,
-    QGroupBox, QCheckBox, QRadioButton,
-    QPushButton, QLabel, QDialog, QLineEdit,
-    QFileDialog, QProgressBar,
+    QHBoxLayout, QVBoxLayout,
+    QPushButton, QLabel, QDialog,
+    QFileDialog, QMessageBox
 )
 
 from featureforest.utils.usage_stats import SegmentationUsageStats
@@ -12,19 +11,21 @@ from featureforest.utils.usage_stats import SegmentationUsageStats
 class UsageStats(QDialog):
     def __init__(self, stats: SegmentationUsageStats) -> None:
         super().__init__()
+        self.setModal(True)
         self.stats = stats
-        # widgets & layout
-        info_label = QLabel()
+        # widgets
+        self.info_label = QLabel()
         save_button = QPushButton("Save as CSV")
         save_button.setMinimumWidth(150)
         save_button.clicked.connect(self.save_stats)
+        save_button.setDefault(True)
         reset_button = QPushButton("Reset")
         reset_button.setMinimumWidth(150)
         reset_button.clicked.connect(self.reset)
-
+        # layouts
         layout = QVBoxLayout()
         layout.setSpacing(1)
-        layout.addWidget(info_label)
+        layout.addWidget(self.info_label)
         hbox = QHBoxLayout()
         hbox.addWidget(save_button, alignment=Qt.AlignHCenter)
         hbox.addWidget(reset_button, alignment=Qt.AlignHCenter)
@@ -32,11 +33,26 @@ class UsageStats(QDialog):
         self.setLayout(layout)
         self.setMinimumWidth(500)
 
+        self.show_stats()
+
+    def show_stats(self):
+        df = self.stats.to_dataframe()
+        self.info_label.setText(df.to_html(index=False))
+
     def save_stats(self):
-        pass
+        selected_file, _filter = QFileDialog.getSaveFileName(
+            self, "FeatureForest", ".", "CSV file(*.csv)"
+        )
+        if selected_file is not None and len(selected_file) > 0:
+            self.stats.save_as_csv(selected_file)
+            self.close()
 
     def reset(self):
-        pass
+        confirmed = QMessageBox.question(self, "Confirm Reset", "Are you sure?")
+        if confirmed == QMessageBox.Yes:
+            self.stats.reset()
+            self.show_stats()
+            # self.info_label.setText("Reset!")
 
 
 

--- a/src/featureforest/widgets/usage_stats.py
+++ b/src/featureforest/widgets/usage_stats.py
@@ -1,0 +1,55 @@
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QWidget, QHBoxLayout, QVBoxLayout,
+    QGroupBox, QCheckBox, QRadioButton,
+    QPushButton, QLabel, QDialog, QLineEdit,
+    QFileDialog, QProgressBar,
+)
+
+from featureforest.utils.usage_stats import SegmentationUsageStats
+
+
+class UsageStats(QDialog):
+    def __init__(self, stats: SegmentationUsageStats) -> None:
+        super().__init__()
+        self.stats = stats
+        # widgets & layout
+        info_label = QLabel()
+        save_button = QPushButton("Save as CSV")
+        save_button.setMinimumWidth(150)
+        save_button.clicked.connect(self.save_stats)
+        reset_button = QPushButton("Reset")
+        reset_button.setMinimumWidth(150)
+        reset_button.clicked.connect(self.reset)
+
+        layout = QVBoxLayout()
+        layout.setSpacing(1)
+        layout.addWidget(info_label)
+        hbox = QHBoxLayout()
+        hbox.addWidget(save_button, alignment=Qt.AlignHCenter)
+        hbox.addWidget(reset_button, alignment=Qt.AlignHCenter)
+        layout.addLayout(hbox)
+        self.setLayout(layout)
+        self.setMinimumWidth(500)
+
+    def save_stats(self):
+        pass
+
+    def reset(self):
+        pass
+
+
+
+
+if __name__ == "__main__":
+    import sys
+    from qtpy.QtWidgets import QApplication
+
+
+    stats = SegmentationUsageStats()
+
+    app = QApplication(sys.argv)
+    widget = UsageStats(stats)
+    widget.show()
+
+    sys.exit(app.exec_())


### PR DESCRIPTION
- Feature extraction timing stats will be saved as a *csv* file beside the selected *feature storage file*.
    - same file name as the storage file with `_ext_stats.csv` suffix.
 
![Screenshot 2025-01-21 at 13 49 40](https://github.com/user-attachments/assets/51e8510a-4ae6-4e20-ac7b-68db92adb231)
![Screenshot 2025-01-21 at 13 53 55](https://github.com/user-attachments/assets/089dd307-8dce-40c3-a7f2-994dc0ac1cae)

- Segmentation stats will also be saved beside the storage file: `..._seg_stats.csv`:
    - Including `labeling`, `last_training`, `average_training`, `num_trainings`, `prediction_time`,	`num_predictions`
    - `labeling` time is a calculation, starting from the very first added label til the last one (you should reduce your tea time on your own calculation 😁).
    - These stats can be checked using the `Plugin Usage Stats` button.
    - It is possible to reset them!
![Screenshot 2025-01-22 at 15 00 07](https://github.com/user-attachments/assets/27d02aca-5e4e-4753-8a4f-87c6fb7bd2b4)

- Prediction pipeline's stats (over a large stack) will be saved in the selected *result* folder.
 
![Screenshot 2025-01-22 at 15 00 59](https://github.com/user-attachments/assets/af369986-f03c-4b41-a5ea-b76d5e8d5141)
