### PR TITLE
added cellpose cyto3 encoder model

### DIFF
--- a/src/featureforest/models/Cellpose/__init__.py
+++ b/src/featureforest/models/Cellpose/__init__.py
@@ -1,0 +1,7 @@
+from .adapter import CellposeAdapter
+from .model import get_model
+
+__all__ = [
+    "get_model",
+    "CellposeAdapter",
+]

--- a/src/featureforest/models/Cellpose/adapter.py
+++ b/src/featureforest/models/Cellpose/adapter.py
@@ -1,0 +1,75 @@
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torchvision.transforms import v2 as tv_transforms2
+
+from featureforest.models.base import BaseModelAdapter
+from featureforest.utils.data import (
+    get_nonoverlapped_patches,
+    get_patch_size,
+)
+
+
+class CellposeAdapter(BaseModelAdapter):
+    """Cellpose model adapter"""
+
+    def __init__(
+        self,
+        image_encoder: nn.Module,
+        img_height: float,
+        img_width: float,
+        device: torch.device,
+        name: str = "Cellpose_cyto3",
+    ) -> None:
+        super().__init__(image_encoder, img_height, img_width, device)
+        # for different flavors of SAM2 only the name is different.
+        self.name = name
+        self.encoder = image_encoder
+        # self.encoder_num_channels = 480
+        self.device = device
+        self._set_patch_size()
+        assert (
+            int(self.patch_size / 4) == self.patch_size / 4
+        ), f"patch size {self.patch_size} is not divisible by 4"
+
+        # input transform for sam
+        self.input_transforms = None
+        # to transform feature patches back to the original patch size
+        self.embedding_transform = tv_transforms2.Compose(
+            [
+                tv_transforms2.Resize(
+                    (self.patch_size, self.patch_size),
+                    interpolation=tv_transforms2.InterpolationMode.BICUBIC,
+                    antialias=True,
+                ),
+            ]
+        )
+
+    def _set_patch_size(self) -> None:
+        self.patch_size = get_patch_size(self.img_height, self.img_width)
+        self.overlap = self.patch_size // 2
+
+    def get_features_patches(self, in_patches: Tensor) -> tuple[Tensor, Tensor]:
+        # cellpose works on microscopic channels not RGB
+        # we need to select one channel and add a second zero channel
+        in_patches = torch.cat(
+            [in_patches[:, 0:1], torch.zeros_like(in_patches[:, 0:1])], dim=1
+        )
+        # get the image encoder outputs
+        with torch.no_grad():
+            output = self.encoder(in_patches)
+        # output has four levels of features from hight to low resolution.
+        # [b, 32, p, p]
+        # [b, 64, p/2, p/2]
+        # [b, 128, p/4, p/4]
+        # [b, 256, p/8, p/8]
+        features = [self.embedding_transform(feat.cpu()) for feat in output]
+        features = torch.cat(features, dim=1)
+        out_feature_patches = get_nonoverlapped_patches(
+            features, self.patch_size, self.overlap
+        )
+
+        return out_feature_patches
+
+    def get_total_output_channels(self) -> int:
+        return 32 + 64 + 128 + 256  # 480

--- a/src/featureforest/models/Cellpose/cellpose_downsample.py
+++ b/src/featureforest/models/Cellpose/cellpose_downsample.py
@@ -1,0 +1,74 @@
+"""
+Copyright © 2023 Howard Hughes Medical Institute,
+Authored by Carsen Stringer and Marius Pachitariu.
+"""
+
+import torch.nn as nn
+
+
+def batchconv(in_channels, out_channels, sz, conv_3D=False):
+    conv_layer = nn.Conv3d if conv_3D else nn.Conv2d
+    batch_norm = nn.BatchNorm3d if conv_3D else nn.BatchNorm2d
+    return nn.Sequential(
+        batch_norm(in_channels, eps=1e-5, momentum=0.05),
+        nn.ReLU(inplace=True),
+        conv_layer(in_channels, out_channels, sz, padding=sz // 2),
+    )
+
+
+def batchconv0(in_channels, out_channels, sz, conv_3D=False):
+    conv_layer = nn.Conv3d if conv_3D else nn.Conv2d
+    batch_norm = nn.BatchNorm3d if conv_3D else nn.BatchNorm2d
+    return nn.Sequential(
+        batch_norm(in_channels, eps=1e-5, momentum=0.05),
+        conv_layer(in_channels, out_channels, sz, padding=sz // 2),
+    )
+
+
+class resdown(nn.Module):
+    def __init__(self, in_channels, out_channels, sz, conv_3D=False):
+        super().__init__()
+        self.conv = nn.Sequential()
+        self.proj = batchconv0(in_channels, out_channels, 1, conv_3D)
+        for t in range(4):
+            if t == 0:
+                self.conv.add_module(
+                    f"conv_{t}", batchconv(in_channels, out_channels, sz, conv_3D)
+                )
+            else:
+                self.conv.add_module(
+                    f"conv_{t}", batchconv(out_channels, out_channels, sz, conv_3D)
+                )
+
+    def forward(self, x):
+        x = self.proj(x) + self.conv[1](self.conv[0](x))
+        x = x + self.conv[3](self.conv[2](x))
+        return x
+
+
+class downsample(nn.Module):
+    def __init__(self, nbase, sz, conv_3D=False, max_pool=True):
+        super().__init__()
+        self.down = nn.Sequential()
+        if max_pool:
+            self.maxpool = (
+                nn.MaxPool3d(2, stride=2) if conv_3D else nn.MaxPool2d(2, stride=2)
+            )
+        else:
+            self.maxpool = (
+                nn.AvgPool3d(2, stride=2) if conv_3D else nn.AvgPool2d(2, stride=2)
+            )
+        for n in range(len(nbase) - 1):
+            self.down.add_module(
+                f"res_down_{n}", resdown(nbase[n], nbase[n + 1], sz, conv_3D)
+            )
+
+    def forward(self, x):
+        xd = []
+        for n in range(len(self.down)):
+            if n > 0:  # noqa: SIM108
+                y = self.maxpool(xd[n - 1])
+            else:
+                y = x
+            xd.append(self.down[n](y))
+        return xd

--- a/src/featureforest/models/Cellpose/model.py
+++ b/src/featureforest/models/Cellpose/model.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import torch
+
+from featureforest.models.Cellpose.adapter import CellposeAdapter
+from featureforest.models.Cellpose.cellpose_downsample import downsample
+
+
+class Cyto3Encoder(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.nbase = [2, 32, 64, 128, 256]
+        self.sz = 3
+        self.max_pool = True
+        self.downsample = downsample(
+            self.nbase, self.sz, conv_3D=False, max_pool=self.max_pool
+        )
+        # load downsample weights
+        weight_file = Path(__file__).parent.joinpath("cyto3_downsample.pth")
+        assert weight_file.exists(), "Couldn't find cellpose weights"
+        self.downsample.load_state_dict(torch.load(weight_file, map_location="cpu"))
+
+    def forward(self, x):
+        out = self.downsample(x)
+        return out
+
+
+def get_model(img_height: float, img_width: float, *args, **kwargs) -> CellposeAdapter:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"running on {device}")
+    # init the model
+    model = Cyto3Encoder().to(device)
+    model.eval()
+
+    # create the model adapter
+    cellpose_adapter = CellposeAdapter(
+        model, img_height, img_width, device, "Cellpose_cyto3"
+    )
+
+    return cellpose_adapter
+
+
+if __name__ == "__main__":
+    model = Cyto3Encoder()
+    print(model)

--- a/src/featureforest/models/__init__.py
+++ b/src/featureforest/models/__init__.py
@@ -1,26 +1,26 @@
-from typing import List
 from functools import partial
 
 from .base import BaseModelAdapter
+from .Cellpose import get_model as get_cellpose_model
+from .DinoV2 import get_model as get_dino_v2_model
 from .MobileSAM import get_model as get_mobile_sam_model
 from .SAM import get_model as get_sam_model
-from .DinoV2 import get_model as get_dino_v2_model
-from .SAM2 import get_large_model as get_sam2_large_model
 from .SAM2 import get_base_model as get_sam2_base_model
-
+from .SAM2 import get_large_model as get_sam2_large_model
 
 _MODELS_DICT = {
     "SAM2_Large": get_sam2_large_model,
     "SAM2_Base": get_sam2_base_model,
+    "μSAM_LM": partial(get_sam_model, model_type="vit_b_lm"),
+    "μSAM_EM_Organelles": partial(get_sam_model, model_type="vit_b_em_organelles"),
+    "Cellpose_cyto3": get_cellpose_model,
     "MobileSAM": get_mobile_sam_model,
     "SAM": get_sam_model,
     "DinoV2": get_dino_v2_model,
-    "μSAM_LM": partial(get_sam_model, model_type="vit_b_lm"),
-    "μSAM_EM_Organelles": partial(get_sam_model, model_type="vit_b_em_organelles"),
 }
 
 
-def get_available_models() -> List[str]:
+def get_available_models() -> list[str]:
     return list(_MODELS_DICT.keys())
 
 


### PR DESCRIPTION
- Added *Cellpose cyto3* encoder model.
- I borrowed the encoder code from the [cellpose repo](https://github.com/MouseLand/cellpose/blob/main/cellpose/resnet_torch.py)
- The model weights are only 11.2 MB, which is included in the repo.