### PR TITLE
Update pyproject.toml to not depend on PyQt5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "scikit-image",
     "matplotlib",
     "pynrrd",
-    "PyQt5",
     "magicgui",
     "qtpy",
     "napari",
@@ -72,6 +71,7 @@ dev = [
     "tox-gh-actions",
     "sybil",      # doctesting
 ]
+all = ["napari[all]"]
 [project.urls]
 homepage = "https://featureforest.github.io/"
 repository = "https://github.com/juglab/featureforest"


### PR DESCRIPTION
Closes https://github.com/juglab/featureforest/issues/37

This PR removes PyQt5 from direct dependencies and instead adds [all] that includes `napari[all]` so that a pip install using `featureforest[all]` will include a default Qt backend out of the box.
