### PR TITLE
Updated prediction pipeline using no storage file and multiprocessing

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -198,6 +198,8 @@ def main(
     # result folder
     segmentation_dir = Path(output_dir)
     segmentation_dir.mkdir(parents=True, exist_ok=True)
+    prediction_dir = segmentation_dir.joinpath("Prediction")
+    prediction_dir.mkdir(exist_ok=True)
 
     # get patch sizes
     input_stack = Image.open(data_path)
@@ -268,7 +270,7 @@ def main(
             )
 
         img = Image.fromarray(slice_mask)
-        img.save(segmentation_dir.joinpath(f"slice_{i:04}_prediction.tiff"))
+        img.save(prediction_dir.joinpath(f"slice_{i:04}_prediction.tiff"))
 
         if do_postprocess:
             post_masks = apply_postprocessing(

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,3 +1,4 @@
+import time
 import argparse
 import multiprocessing as mp
 import pickle
@@ -238,6 +239,7 @@ def main(
     sam_autoseg_iou_threshold = 0.35
 
     # ### Prediction
+    tic = time.perf_counter()
     for i, page in enumerate(ImageSequence.Iterator(input_stack)):
         print(f"\nslice {i + 1}")
         slide_img = np.array(page.convert("RGB"))
@@ -285,6 +287,8 @@ def main(
                 seg_dir = segmentation_dir.joinpath(name)
                 seg_dir.mkdir(exist_ok=True)
                 img.save(seg_dir.joinpath(f"slice_{i:04}_{name}.tiff"))
+
+    print(f"total elapsed time: {(time.perf_counter() - tic)} seconds")
 
 
 if __name__ == "__main__":

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -127,7 +127,7 @@ def get_slice_features(
     # get sam encoder output for image patches
     print("\nextracting slice features:")
     for b_idx in range(num_batches):
-        # print(f"batch #{b_idx + 1} of {num_batches}")
+        print(f"batch #{b_idx + 1} of {num_batches}")
         start = b_idx * batch_size
         end = start + batch_size
         slice_features = model_adapter.get_features_patches(
@@ -256,7 +256,6 @@ def main(
             # wait until all processes are done
             for p in procs:
                 if p.is_alive:
-                    print(p.name)
                     p.join()
             # collect results from each process
             batch_indices = sorted(result_dict.keys())

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -126,7 +126,7 @@ def get_slice_features(
     num_batches = int(np.ceil(num_patches / batch_size))
 
     # get sam encoder output for image patches
-    print("\nextracting slice features:")
+    print("extracting slice features:")
     for b_idx in range(num_batches):
         print(f"batch #{b_idx + 1} of {num_batches}")
         start = b_idx * batch_size

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,36 +1,108 @@
-import pickle
 import argparse
+import multiprocessing as mp
+import pickle
+from collections.abc import Generator
 from pathlib import Path
 
-import h5py
 import numpy as np
 import torch
 from PIL import Image, ImageSequence
+from sklearn.ensemble import RandomForestClassifier as RF
 
-from featureforest.models import get_available_models, get_model
+from featureforest.models import BaseModelAdapter, get_available_models, get_model
 from featureforest.models.SAM import SAMAdapter
-from featureforest.utils.data import (
-    patchify,
-    is_image_rgb, get_stride_margin,
-    get_num_patches
-)
 from featureforest.postprocess import (
+    get_sam_auto_masks,
     postprocess,
-    postprocess_with_sam, postprocess_with_sam_auto,
-    get_sam_auto_masks
+    postprocess_with_sam,
+    postprocess_with_sam_auto,
 )
+from featureforest.utils.data import (
+    get_num_patches,
+    get_stride_margin,
+    is_image_rgb,
+    patchify,
+)
+
+
+def predict_patches(
+    patch_features: np.ndarray,
+    rf_model: RF,
+    model_adapter: BaseModelAdapter,
+    batch_idx: int,
+    result_dict: dict,
+) -> None:
+    """Predicts the class labels for a given set of patch features.
+
+    Args:
+        patch_features (np.ndarray): Patch features to be predicted.
+        rf_model (RF): Random Forest Model used for predictions.
+        model_adapter (BaseModelAdapter): Model adapter object used for extracting data.
+        batch_idx (int): Batch index of the current patch features.
+        result_dict (dict): Dictionary where the predicted masks will be stored.
+    """
+    patch_masks = []
+    # shape: N x target_size x target_size x C
+    num_patches = patch_features.shape[0]
+    total_channels = model_adapter.get_total_output_channels()
+    print(f"predicting {num_patches} patches...")
+    for i in range(num_patches):
+        patch_data = patch_features[i].reshape(-1, total_channels)
+        pred = rf_model.predict(patch_data).astype(np.uint8)
+        patch_masks.append(pred)
+
+    patch_masks = np.vstack(patch_masks)
+    result_dict[batch_idx] = patch_masks
+
+
+def get_image_mask(
+    patch_masks: np.ndarray,
+    img_height: int,
+    img_width: int,
+    patch_size: int,
+    overlap: int,
+) -> np.ndarray:
+    """Gets the final image mask by combining the individual patch masks.
+
+    Args:
+        patch_masks (ndarray): Patch masks to combine into an image mask.
+        img_height (int): Height of the input image.
+        img_width (int): Width of the input image.
+        patch_size (int): Size of the patches.
+        overlap (int): Overlap between adjacent patches.
+
+    Returns:
+        np.ndarray: Final image mask.
+    """
+    stride, _ = get_stride_margin(patch_size, overlap)
+    patch_rows, patch_cols = get_num_patches(img_height, img_width, patch_size, overlap)
+    mask_image = patch_masks.reshape(patch_rows, patch_cols, stride, stride)
+    mask_image = np.moveaxis(mask_image, 1, 2).reshape(
+        patch_rows * stride, patch_cols * stride
+    )
+    # skip paddings
+    mask_image = mask_image[:img_height, :img_width]
+
+    return mask_image
 
 
 def get_slice_features(
-    image: np.ndarray,
-    patch_size: int,
-    overlap: int,
-    model_adapter,
-    storage_group,
-):
-    """Extract the model features for one slice and save them into storage file."""
+    image: np.ndarray, model_adapter: BaseModelAdapter
+) -> Generator[tuple[int, np.ndarray], None, None]:
+    """Extract features for one image using the given model adapter
+
+    Args:
+        image: Input image array
+        model_adapter: Model adapter to extract features from
+    Returns:
+        Generator yielding tuples containing batch index and extracted features.
+    """
     # image to torch tensor
-    img_data = torch.from_numpy(image).to(torch.float32) / 255.0
+    img_data = torch.from_numpy(image).to(torch.float32)
+    # normalize in [0, 1]
+    _min = img_data.min()
+    _max = img_data.max()
+    img_data = (img_data - _min) / (_max - _min)
     # for sam the input image should be 4D: BxCxHxW ; an RGB image.
     if is_image_rgb(image):
         # it's already RGB, put the channels first and add a batch dim.
@@ -40,6 +112,8 @@ def get_slice_features(
         img_data = img_data.unsqueeze(0).unsqueeze(0).expand(-1, 3, -1, -1)
 
     # get input patches
+    patch_size = model_adapter.patch_size
+    overlap = model_adapter.overlap
     data_patches = patchify(img_data, patch_size, overlap)
     num_patches = len(data_patches)
 
@@ -48,18 +122,7 @@ def get_slice_features(
     # for big SAM we need even lower batch size :(
     if isinstance(model_adapter, SAMAdapter):
         batch_size = 2
-
     num_batches = int(np.ceil(num_patches / batch_size))
-    # prepare storage for the slice embeddings
-    total_channels = model_adapter.get_total_output_channels()
-    stride, _ = get_stride_margin(patch_size, overlap)
-
-    if model_adapter.name not in storage_group:
-        dataset = storage_group.create_dataset(
-            model_adapter.name, shape=(num_patches, stride, stride, total_channels)
-        )
-    else:
-        dataset = storage_group[model_adapter.name]
 
     # get sam encoder output for image patches
     print("\nextracting slice features:")
@@ -69,74 +132,33 @@ def get_slice_features(
         end = start + batch_size
         slice_features = model_adapter.get_features_patches(
             data_patches[start:end].to(model_adapter.device)
-        )
-        if not isinstance(slice_features, tuple):
-            # model has only one output
-            num_out = slice_features.shape[0]  # to take care of the last batch size
-            dataset[start: start + num_out] = slice_features
-        else:
-            # model has more than one output: put them into storage one by one
-            ch_start = 0
-            for feat in slice_features:
-                num_out = feat.shape[0]
-                ch_end = ch_start + feat.shape[-1]  # number of features
-                dataset[start: start + num_out, :, :, ch_start:ch_end] = feat
-                ch_start = ch_end
+        ).cpu()
+        if isinstance(slice_features, tuple):  # model with more than one output
+            slice_features = torch.cat(slice_features, dim=-1)
 
-
-def predict_slice(
-    rf_model, patch_dataset, model_adapter,
-    img_height, img_width, patch_size, overlap
-):
-    """Predict a slice patch by patch"""
-    segmentation_image = []
-    # shape: N x target_size x target_size x C
-    feature_patches = patch_dataset[:]
-    num_patches = feature_patches.shape[0]
-    total_channels = model_adapter.get_total_output_channels()
-    stride, margin = get_stride_margin(patch_size, overlap)
-
-    print("Predicting slice patches")
-    for i in range(num_patches):
-        input_data = feature_patches[i].reshape(-1, total_channels)
-        predictions = rf_model.predict(input_data).astype(np.uint8)
-        segmentation_image.append(predictions)
-
-    segmentation_image = np.vstack(segmentation_image)
-    # reshape into the image size + padding
-    patch_rows, patch_cols = get_num_patches(
-        img_height, img_width, patch_size, overlap
-    )
-    segmentation_image = segmentation_image.reshape(
-        patch_rows, patch_cols, stride, stride
-    )
-    segmentation_image = np.moveaxis(segmentation_image, 1, 2).reshape(
-        patch_rows * stride,
-        patch_cols * stride
-    )
-    # skip paddings
-    segmentation_image = segmentation_image[:img_height, :img_width]
-
-    return segmentation_image
+        yield b_idx, slice_features.numpy()
 
 
 def apply_postprocessing(
-    input_image, segmentation_image,
-    smoothing_iterations, area_threshold, area_is_absolute,
-    use_sam_predictor, use_sam_autoseg, iou_threshold
-):
+    input_image: np.ndarray,
+    segmentation_image: np.ndarray,
+    smoothing_iterations: int,
+    area_threshold: int,
+    area_is_absolute: bool,
+    use_sam_predictor: bool,
+    use_sam_autoseg: bool,
+    iou_threshold: float,
+) -> np.ndarray:
     post_masks = {}
     # if not use_sam_predictor and not use_sam_autoseg:
     mask = postprocess(
-        segmentation_image, smoothing_iterations,
-        area_threshold, area_is_absolute
+        segmentation_image, smoothing_iterations, area_threshold, area_is_absolute
     )
     post_masks["Simple"] = mask
 
     if use_sam_predictor:
         mask = postprocess_with_sam(
-            segmentation_image,
-            smoothing_iterations, area_threshold, area_is_absolute
+            segmentation_image, smoothing_iterations, area_threshold, area_is_absolute
         )
         post_masks["SAMPredictor"] = mask
 
@@ -145,8 +167,10 @@ def apply_postprocessing(
         mask = postprocess_with_sam_auto(
             sam_auto_masks,
             segmentation_image,
-            smoothing_iterations, iou_threshold,
-            area_threshold, area_is_absolute
+            smoothing_iterations,
+            iou_threshold,
+            area_threshold,
+            area_is_absolute,
         )
         post_masks["SAMAutoSegmentation"] = mask
 
@@ -154,20 +178,24 @@ def apply_postprocessing(
 
 
 def main(
-    data_path, rf_model_path, result_dir,
-    model_name="SAM2_Large", storage_path="./temp_storage.hdf5",
-    smoothing_iterations=25, area_threshold=50, use_sam_predictor=True
+    input_file: str,
+    rf_model_file: str,
+    output_dir: str,
+    model_name: str = "SAM2_Large",
+    smoothing_iterations: int = 25,
+    area_threshold: int = 50,
+    use_sam_predictor: bool = True,
 ):
     # input image
-    data_path = Path(data_path)
+    data_path = Path(input_file)
     print(f"data_path exists: {data_path.exists()}")
 
     # random forest model
-    rf_model_path = Path(rf_model_path)
+    rf_model_path = Path(rf_model_file)
     print(f"rf_model_path exists: {rf_model_path.exists()}")
 
     # result folder
-    segmentation_dir = Path(result_dir)
+    segmentation_dir = Path(output_dir)
     segmentation_dir.mkdir(parents=True, exist_ok=True)
 
     # get patch sizes
@@ -194,11 +222,10 @@ def main(
 
     # list of available models
     available_models = get_available_models()
-    assert model_name in available_models, \
-        f"Couln't find {model_name} in available models\n{available_models}."
+    assert (
+        model_name in available_models
+    ), f"Couldn't find {model_name} in available models\n{available_models}."
 
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # print(f"running on {device}")
     model_adapter = get_model(model_name, img_height, img_width)
     patch_size = model_adapter.patch_size
     overlap = model_adapter.overlap
@@ -206,35 +233,52 @@ def main(
 
     # post-processing parameters
     do_postprocess = True
-    area_is_absolute = True      # is area is based on pixels or percentage (False)
+    area_is_absolute = True  # is area is based on pixels or percentage (False)
     use_sam_autoseg = False
     sam_autoseg_iou_threshold = 0.35
 
     # ### Prediction
-    # create the slice temporary storage
-    storage = h5py.File(storage_path, "w")
-    storage_group = storage.create_group("slice")
-
     for i, page in enumerate(ImageSequence.Iterator(input_stack)):
         print(f"\nslice {i + 1}")
-        slice_img = np.array(page.convert("RGB"))
+        slide_img = np.array(page.convert("RGB"))
+        procs = []
+        # random forest prediction happens per batch of extracted features
+        # in a separate process.
+        with mp.Manager() as manager:
+            result_dict = manager.dict()
+            for b_idx, patch_features in get_slice_features(slide_img, model_adapter):
+                proc = mp.Process(
+                    target=predict_patches,
+                    args=(patch_features, rf_model, model_adapter, b_idx, result_dict),
+                )
+                procs.append(proc)
+                proc.start()
+            # wait until all processes are done
+            for p in procs:
+                if p.is_alive:
+                    print(p.name)
+                    p.join()
+            # collect results from each process
+            batch_indices = sorted(result_dict.keys())
+            patch_masks = [result_dict[b] for b in batch_indices]
+            patch_masks = np.vstack(patch_masks)
+            slice_mask = get_image_mask(
+                patch_masks, img_height, img_width, patch_size, overlap
+            )
 
-        get_slice_features(slice_img, patch_size, overlap, model_adapter, storage_group)
-
-        segmentation_image = predict_slice(
-            rf_model, storage_group[model_adapter.name], model_adapter,
-            img_height, img_width,
-            patch_size, overlap
-        )
-
-        img = Image.fromarray(segmentation_image)
+        img = Image.fromarray(slice_mask)
         img.save(segmentation_dir.joinpath(f"slice_{i:04}_prediction.tiff"))
 
         if do_postprocess:
             post_masks = apply_postprocessing(
-                slice_img, segmentation_image,
-                smoothing_iterations, area_threshold, area_is_absolute,
-                use_sam_predictor, use_sam_autoseg, sam_autoseg_iou_threshold
+                slide_img,
+                slice_mask,
+                smoothing_iterations,
+                area_threshold,
+                area_is_absolute,
+                use_sam_predictor,
+                use_sam_autoseg,
+                sam_autoseg_iou_threshold,
             )
             # save results
             for name, mask in post_masks.items():
@@ -242,11 +286,6 @@ def main(
                 seg_dir = segmentation_dir.joinpath(name)
                 seg_dir.mkdir(exist_ok=True)
                 img.save(seg_dir.joinpath(f"slice_{i:04}_{name}.tiff"))
-
-    if storage is not None:
-        storage.close()
-        storage = None
-    Path(storage_path).unlink()
 
 
 if __name__ == "__main__":
@@ -257,31 +296,37 @@ if __name__ == "__main__":
     parser.add_argument("--rf_model", help="Path to the trained RF model", required=True)
     parser.add_argument("--outdir", help="Path to the output directory", required=True)
     parser.add_argument(
-        "--feat_model", choices=get_available_models(),
-        help="Name of the model for feature extraction"
+        "--feat_model",
+        choices=get_available_models(),
+        help="Name of the model for feature extraction",
     )
     parser.add_argument(
-        "--storage", default="./temp_storage.hdf5", help="Temporary storage file path"
+        "--smoothing_iterations",
+        default=25,
+        type=int,
+        help="Post-processing smoothing iterations; default=25",
     )
     parser.add_argument(
-        "--smoothing_iterations", default=25, type=int,
-        help="Post-processing smoothing iterations; default=25"
+        "--area_threshold",
+        default=50,
+        type=int,
+        help="Post-processing area threshold to remove small regions; default=50",
     )
     parser.add_argument(
-        "--area_threshold", default=50, type=int,
-        help="Post-processing area threshold to remove small regions; default=50"
-    )
-    parser.add_argument(
-        "--use_sam_predictor", default=True, action="store_true",
-        help="To use SAM2 for generating final masks"
+        "--use_sam_predictor",
+        default=True,
+        action="store_true",
+        help="To use SAM2 for generating final masks",
     )
 
     args = parser.parse_args()
 
     main(
-        data_path=args.data, rf_model_path=args.rf_model, model_name=args.feat_model,
-        result_dir=args.outdir, storage_path=args.storage,
+        input_file=args.data,
+        rf_model_file=args.rf_model,
+        output_dir=args.outdir,
+        model_name=args.feat_model,
         smoothing_iterations=args.smoothing_iterations,
         area_threshold=args.area_threshold,
-        use_sam_predictor=args.use_sam_predictor
+        use_sam_predictor=args.use_sam_predictor,
     )

--- a/src/featureforest/postprocess/postprocess_with_sam.py
+++ b/src/featureforest/postprocess/postprocess_with_sam.py
@@ -1,47 +1,43 @@
-from typing import List, Tuple
-
-from napari.utils import progress as np_progress
-# import napari.utils.notifications as notif
-
-import numpy as np
 import cv2
+
+# import napari.utils.notifications as notif
+import numpy as np
 import torch
-
 from cv2.typing import Rect
-from sam2.modeling.sam2_base import SAM2Base
-from sam2.build_sam import build_sam2
-from sam2.sam2_image_predictor import SAM2ImagePredictor
+from napari.utils import progress as np_progress
 from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
+from sam2.build_sam import build_sam2
+from sam2.modeling.sam2_base import SAM2Base
+from sam2.sam2_image_predictor import SAM2ImagePredictor
 
+from featureforest.utils.data import image_to_uint8, is_image_rgb
 from featureforest.utils.downloader import download_model
-from featureforest.utils.data import is_image_rgb, image_to_uint8
+
 from .postprocess import postprocess_label_mask
 
 
 def get_sam2() -> SAM2Base:
-    model_url = \
-        "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt"
+    model_url = "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt"
     model_file = download_model(
-        model_url=model_url,
-        model_name="sam2.1_hiera_base_plus.pt"
+        model_url=model_url, model_name="sam2.1_hiera_base_plus.pt"
     )
     if model_file is None:
         raise ValueError(f"Could not download the model from {model_url}.")
 
     # init the model
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"running on {device}")
+    # print(f"running on {device}")
     sam2_model: SAM2Base = build_sam2(
-        config_file= "configs/sam2.1/sam2.1_hiera_b+.yaml",
+        config_file="configs/sam2.1/sam2.1_hiera_b+.yaml",
         ckpt_path=model_file,
-        device=device
+        device=device,
     )
     sam2_model.eval()
 
     return sam2_model
 
 
-def get_watershed_bboxes(image: np.ndarray) -> List[Rect]:
+def get_watershed_bboxes(image: np.ndarray) -> list[Rect]:
     """Apply watershed algorithm to the input binary image
     to get bounding boxes.
 
@@ -86,7 +82,7 @@ def get_watershed_bboxes(image: np.ndarray) -> List[Rect]:
     return bboxes
 
 
-def get_bounding_boxes(image: np.ndarray) -> List[Rect]:
+def get_bounding_boxes(image: np.ndarray) -> list[Rect]:
     """Getting bounding boxes around contours in the input image.
 
     Args:
@@ -95,9 +91,7 @@ def get_bounding_boxes(image: np.ndarray) -> List[Rect]:
     Returns:
         List[Rect]: list of bounding boxes
     """
-    contours, _ = cv2.findContours(
-        image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
-    )
+    contours, _ = cv2.findContours(image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     bboxes = []
     for cnt in contours:
         bboxes.append(cv2.boundingRect(cnt))
@@ -106,7 +100,7 @@ def get_bounding_boxes(image: np.ndarray) -> List[Rect]:
 
 
 def get_sam_mask(
-    predictor: SAM2ImagePredictor, image: np.ndarray, bboxes: List[Rect]
+    predictor: SAM2ImagePredictor, image: np.ndarray, bboxes: list[Rect]
 ) -> np.ndarray:
     """Returns a mask aggregated by sam predictor masks for each given bounding box.
 
@@ -122,17 +116,14 @@ def get_sam_mask(
     image = np.repeat(image[:, :, np.newaxis], 3, axis=2)
     predictor.set_image(image)
     # get sam-ready bounding boxes: x,y,w,h -> x1,y1,x2,y2
-    input_boxes = np.array([
-        (box[0], box[1], box[0] + box[2], box[1] + box[3])
-        for box in bboxes
-    ])
+    input_boxes = np.array(
+        [(box[0], box[1], box[0] + box[2], box[1] + box[3]) for box in bboxes]
+    )
     # get sam predictor masks
     bs = 16
     num_batches = np.ceil(len(bboxes) / bs).astype(int)
     final_mask = np.zeros((image.shape[0], image.shape[1]), dtype=bool)
-    for i in np_progress(
-        range(num_batches), desc="Generating masks using SAM predictor"
-    ):
+    for i in np_progress(range(num_batches), desc="Generating masks using SAM predictor"):
         start = i * bs
         end = start + bs
         masks, _, _ = predictor.predict(
@@ -143,8 +134,7 @@ def get_sam_mask(
         )
         reduced_axis = (0, 1) if masks.ndim == 4 else 0
         final_mask = np.bitwise_or(
-            final_mask,
-            np.bitwise_or.reduce(masks.astype(bool), axis=reduced_axis)
+            final_mask, np.bitwise_or.reduce(masks.astype(bool), axis=reduced_axis)
         )
 
     return final_mask
@@ -154,7 +144,7 @@ def postprocess_with_sam(
     segmentation_image: np.ndarray,
     smoothing_iterations: int = 25,
     area_threshold: int = 15,
-    area_is_abs: bool = False
+    area_is_abs: bool = False,
 ) -> np.ndarray:
     """Post-processes segmentations using SAM predictor.
 
@@ -177,9 +167,7 @@ def postprocess_with_sam(
     # postprocessing gets done for each label's mask separately.
     bg_label = 0
     class_labels = [c for c in np.unique(segmentation_image) if c > bg_label]
-    for label in np_progress(
-        class_labels, desc="Getting SAM masks for each class"
-    ):
+    for label in np_progress(class_labels, desc="Getting SAM masks for each class"):
         # make a binary image for the label (class)
         bin_image = (segmentation_image == label).astype(np.uint8) * 255
         processed_mask = postprocess_label_mask(
@@ -201,7 +189,7 @@ def postprocess_with_sam(
     return final_mask
 
 
-def get_sam_auto_masks(input_image: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def get_sam_auto_masks(input_image: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Returns masks generated by SamAutomaticMaskGenerator
 
     Args:
@@ -211,10 +199,7 @@ def get_sam_auto_masks(input_image: np.ndarray) -> Tuple[np.ndarray, np.ndarray]
         Tuple[np.ndarray, np.ndarray]: a tuple of (masks, areas)
     """
     if not is_image_rgb(input_image):
-        input_image = np.repeat(
-            input_image[..., np.newaxis],
-            3, axis=-1
-        )
+        input_image = np.repeat(input_image[..., np.newaxis], 3, axis=-1)
     assert is_image_rgb(input_image)
     # normalize the image in [0, 255] as uint8
     image = image_to_uint8(input_image.copy())
@@ -228,7 +213,7 @@ def get_sam_auto_masks(input_image: np.ndarray) -> Tuple[np.ndarray, np.ndarray]
         crop_n_layers=1,
         crop_n_points_downscale_factor=8,
         min_mask_region_area=20,
-        use_m2m=True
+        use_m2m=True,
     )
     # generate SAM2 masks
     print("generating masks using SAM2AutomaticMaskGenerator...")
@@ -263,12 +248,12 @@ def get_ious(mask: np.ndarray, sam_masks: np.ndarray) -> np.ndarray:
 
 
 def postprocess_with_sam_auto(
-    sam_auto_masks: Tuple[np.ndarray, np.ndarray],
+    sam_auto_masks: tuple[np.ndarray, np.ndarray],
     segmentation_image: np.ndarray,
     smoothing_iterations: int = 20,
     iou_threshold: float = 0.45,
     area_threshold: int = 15,
-    area_is_abs: bool = False
+    area_is_abs: bool = False,
 ) -> np.ndarray:
     """Post-processes segmentations using SAM auto-segmentation instances' masks.
 
@@ -297,9 +282,7 @@ def postprocess_with_sam_auto(
     # postprocessing gets done for each class segmentation.
     bg_label = 0
     class_labels = [c for c in np.unique(segmentation_image) if c > bg_label]
-    for class_label in np_progress(
-        class_labels, desc="Getting SAM masks for each class"
-    ):
+    for class_label in np_progress(class_labels, desc="Getting SAM masks for each class"):
         # make a binary image for the label (class)
         bin_image = (segmentation_image == class_label).astype(np.uint8) * 255
         processed_mask = postprocess_label_mask(

--- a/src/featureforest/utils/extract.py
+++ b/src/featureforest/utils/extract.py
@@ -116,9 +116,7 @@ def extract_embeddings_to_file(
             slice_img = image[slice_index].copy() if num_slices > 1 else image.copy()
             slice_img = image_to_uint8(slice_img)  # image must be an uint8 array
             slice_grp = storage.create_group(str(slice_index))
-            for _ in get_slice_features(
-                slice_img, patch_size, overlap, model_adapter, slice_grp
-            ):
+            for _ in get_slice_features(slice_img, model_adapter, slice_grp):
                 pass
 
             yield slice_index, num_slices

--- a/src/featureforest/utils/extract.py
+++ b/src/featureforest/utils/extract.py
@@ -81,13 +81,14 @@ def get_slice_features(
         end = start + batch_size
         slice_features = model_adapter.get_features_patches(
             data_patches[start:end].to(model_adapter.device)
-        ).cpu()
+        )
         if isinstance(slice_features, tuple):  # model with more than one output
             slice_features = torch.cat(slice_features, dim=-1)
         if storage_group is not None:
             # to take care of the last batch size that might be smaller than batch_size
             num_out = slice_features.shape[0]
-            dataset[start : start + num_out] = slice_features.to(torch.float16).numpy()
+            dataset[start: start + num_out] = slice_features.to(
+                torch.float16).cpu().numpy()
             yield b_idx
         else:
             yield b_idx, slice_features.numpy()

--- a/src/featureforest/utils/pipeline_prediction.py
+++ b/src/featureforest/utils/pipeline_prediction.py
@@ -1,73 +1,116 @@
-from napari.utils import progress as np_progress
+import multiprocessing as mp
 
-import h5py
 import numpy as np
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import RandomForestClassifier as RF
 
 from featureforest.models import BaseModelAdapter
-from featureforest.utils.data import (
-    get_stride_margin,
-    get_num_patches
-)
+from featureforest.utils.data import get_num_patches, get_stride_margin
 from featureforest.utils.extract import get_slice_features
 
 
-def predict_slice(
-    rf_model, patch_dataset, model_adapter,
-    img_height, img_width, patch_size, overlap
-):
-    segmentation_image = []
+def predict_patches(
+    patch_features: np.ndarray,
+    rf_model: RF,
+    model_adapter: BaseModelAdapter,
+    batch_idx: int,
+    result_dict: dict,
+) -> None:
+    """Predicts the class labels for a given set of patch features.
+
+    Args:
+        patch_features (np.ndarray): Patch features to be predicted.
+        rf_model (RF): Random Forest Model used for predictions.
+        model_adapter (BaseModelAdapter): Model adapter object used for extracting data.
+        batch_idx (int): Batch index of the current patch features.
+        result_dict (dict): Dictionary where the predicted masks will be stored.
+    """
+    patch_masks = []
     # shape: N x target_size x target_size x C
-    feature_patches = patch_dataset[:]
-    num_patches = feature_patches.shape[0]
+    num_patches = patch_features.shape[0]
     total_channels = model_adapter.get_total_output_channels()
-    stride, margin = get_stride_margin(patch_size, overlap)
+    print(f"predicting {num_patches} patches...")
+    for i in range(num_patches):
+        patch_data = patch_features[i].reshape(-1, total_channels)
+        pred = rf_model.predict(patch_data).astype(np.uint8)
+        patch_masks.append(pred)
 
-    for i in np_progress(range(num_patches), desc="Predicting slice patches"):
-        input_data = feature_patches[i].reshape(-1, total_channels)
-        predictions = rf_model.predict(input_data).astype(np.uint8)
-        segmentation_image.append(predictions)
+    patch_masks = np.vstack(patch_masks)
+    result_dict[batch_idx] = patch_masks
 
-    segmentation_image = np.vstack(segmentation_image)
-    # reshape into the image size + padding
-    patch_rows, patch_cols = get_num_patches(
-        img_height, img_width, patch_size, overlap
-    )
-    segmentation_image = segmentation_image.reshape(
-        patch_rows, patch_cols, stride, stride
-    )
-    segmentation_image = np.moveaxis(segmentation_image, 1, 2).reshape(
-        patch_rows * stride,
-        patch_cols * stride
+
+def get_image_mask(
+    patch_masks: np.ndarray,
+    img_height: int,
+    img_width: int,
+    patch_size: int,
+    overlap: int,
+) -> np.ndarray:
+    """Gets the final image mask by combining the individual patch masks.
+
+    Args:
+        patch_masks (ndarray): Patch masks to combine into an image mask.
+        img_height (int): Height of the input image.
+        img_width (int): Width of the input image.
+        patch_size (int): Size of the patches.
+        overlap (int): Overlap between adjacent patches.
+
+    Returns:
+        np.ndarray: Final image mask.
+    """
+    stride, _ = get_stride_margin(patch_size, overlap)
+    patch_rows, patch_cols = get_num_patches(img_height, img_width, patch_size, overlap)
+    mask_image = patch_masks.reshape(patch_rows, patch_cols, stride, stride)
+    mask_image = np.moveaxis(mask_image, 1, 2).reshape(
+        patch_rows * stride, patch_cols * stride
     )
     # skip paddings
-    segmentation_image = segmentation_image[:img_height, :img_width]
+    mask_image = mask_image[:img_height, :img_width]
 
-    return segmentation_image
+    return mask_image
 
 
 def extract_predict(
-        image: np.ndarray,
-        model_adapter: BaseModelAdapter,
-        storage_group: h5py.Group,
-        rf_model: RandomForestClassifier,
+    image: np.ndarray,
+    model_adapter: BaseModelAdapter,
+    rf_model: RF,
 ) -> np.ndarray:
+    """Extracts features and predicts the classes for a given image.
+
+    Args:
+        image (np.ndarray): Input image to extract features from.
+        model_adapter (BaseModelAdapter): Model adapter object used for extracting data.
+        rf_model (RF): Random Forest Model used for predictions.
+
+    Returns:
+        np.ndarray: Final image mask.
+    """
     img_height, img_width = image.shape[:2]
     patch_size = model_adapter.patch_size
     overlap = model_adapter.overlap
-    # remove old dataset from the storage group
-    for k in storage_group:
-        del storage_group[k]
-    # extract the image features into the h5py temp file.
-    for b_idx in get_slice_features(
-        image, patch_size, overlap, model_adapter, storage_group
-    ):
-        print(b_idx, end="\r")
+    procs = []
+    # prediction happens per batch of extracted features
+    # in a separate process.
+    with mp.Manager() as manager:
+        result_dict = manager.dict()
+        for b_idx, patch_features in get_slice_features(image, model_adapter):
+            # print(b_idx, end="\r")
+            proc = mp.Process(
+                target=predict_patches,
+                args=(patch_features, rf_model, model_adapter, b_idx, result_dict),
+            )
+            procs.append(proc)
+            proc.start()
+        # wait until all processes are done
+        for p in procs:
+            if p.is_alive:
+                print(p.name)
+                p.join()
+        # collect results from each process
+        batch_indices = sorted(result_dict.keys())
+        patch_masks = [result_dict[b] for b in batch_indices]
+        patch_masks = np.vstack(patch_masks)
+        slice_mask = get_image_mask(
+            patch_masks, img_height, img_width, patch_size, overlap
+        )
 
-    prediction_mask = predict_slice(
-        rf_model, storage_group[model_adapter.name], model_adapter,
-        img_height, img_width,
-        patch_size, overlap
-    )
-
-    return prediction_mask
+    return slice_mask

--- a/src/featureforest/utils/pipeline_prediction.py
+++ b/src/featureforest/utils/pipeline_prediction.py
@@ -93,7 +93,7 @@ def extract_predict(
     with mp.Manager() as manager:
         result_dict = manager.dict()
         for b_idx, patch_features in get_slice_features(image, model_adapter):
-            # print(b_idx, end="\r")
+            print(b_idx, end="\r")
             proc = mp.Process(
                 target=predict_patches,
                 args=(patch_features, rf_model, model_adapter, b_idx, result_dict),
@@ -103,7 +103,6 @@ def extract_predict(
         # wait until all processes are done
         for p in procs:
             if p.is_alive:
-                print(p.name)
                 p.join()
         # collect results from each process
         batch_indices = sorted(result_dict.keys())


### PR DESCRIPTION
This update eliminates the need for temporary storage file for saving extracted features.  
As usual, image divided into patches. Then after features of each batch were extracted, patch-wise prediction happens in another process while the next batch fed into the feature extraction model.  
In this way, all `io` operations for saving / reading features into / from a storage file are eliminated and prediction over a large stack can happen much faster (about 20-25% faster with limited tests that I did).  